### PR TITLE
リダイレクトパスを修正

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,8 @@
 title:
 email: contact@iggg.org
 description: > # this means to ignore newlines until "baseurl:"
-baseurl: "" # the subpath of your site, e.g. /blog/
-url: "" # the base hostname & protocol for your site
+baseurl: "/guntoh-fes" # the subpath of your site, e.g. /blog/
+url: "https://iggg.github.io" # the base hostname & protocol for your site
 
 twitter_username: IGGGorg
 github_username: IGGG


### PR DESCRIPTION
なんかまえ観れたような気がするんだけど。。。
まぁ GitHub が勝手にやってることなのでしょうがないですね。

多分、設定に `baseurl: "/guntoh-fes"` を追加するとうまくいくと思う。
ローカルではいい感じに HTML が生成されていた。